### PR TITLE
Add support for reproducible builds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,19 @@
 ## Changes
 
+### 0.1.0b4 (unreleased)
+
+#### Features
+
+- Add support for [reproducible builds] which are now enabled by
+  default. When enabled, timestamps in the zip archive are set to a
+  fixed value (configurable via the `SOURCE_DATE_EPOCH` environment
+  variable) and the UNIX access modes of archive members are
+  [normalized to either 0644 or 0755][mode-normalization] depending on
+  whether the file is executable or not.
+
+[reproducible builds]: https://hatch.pypa.io/latest/config/build/#reproducible-builds
+[mode-normalization]: https://github.com/pypa/flit/pull/66
+
 ### 0.1.0b3 (2023-05-10)
 
 #### Features

--- a/README.md
+++ b/README.md
@@ -92,6 +92,21 @@ structure:
         └── more-code.py
 ```
 
+## Reproducible Builds
+
+By default, this plugin attempts to build [reproducible][reproducible
+builds] archives by setting the timestamps of the zip entries to a
+fixed value. When building in reproducible mode, the UNIX file modes
+of the archive entries is also normalized (to either 0644 or 0755
+depending on whether the file is executable.)
+
+The timestamp used for reproducible builds may be configured by
+setting the `SOURCE_DATE_EPOCH` environment variable.
+
+Reproducible builds may be disabled by setting `reproducible = false`
+in an appropriate section of `pyproject.toml` or `hatch.toml`.  See
+Hatch’s documentation on [Build Configuration] for details.
+
 
 ## Author
 
@@ -101,3 +116,6 @@ Jeff Dairiki <dairiki@dairiki.org>
 
 `hatch-zipped-directory` is distributed under the terms of the
 [MIT](https://spdx.org/licenses/MIT.html) license.
+
+[reproducible builds]: https://hatch.pypa.io/latest/config/build/#reproducible-builds
+[Build Configuration]: https://hatch.pypa.io/latest/config/build/

--- a/hatch_zipped_directory/builder.py
+++ b/hatch_zipped_directory/builder.py
@@ -12,7 +12,8 @@ from typing import Iterable
 from typing import Iterator
 from typing import Tuple
 from zipfile import ZIP_DEFLATED
-from zipfile import ZipFile, ZipInfo
+from zipfile import ZipFile
+from zipfile import ZipInfo
 
 from hatchling.builders.config import BuilderConfig
 from hatchling.builders.plugin.interface import BuilderInterface

--- a/hatch_zipped_directory/builder.py
+++ b/hatch_zipped_directory/builder.py
@@ -18,7 +18,8 @@ from zipfile import ZipInfo
 from hatchling.builders.config import BuilderConfig
 from hatchling.builders.plugin.interface import BuilderInterface
 from hatchling.builders.plugin.interface import IncludedFile
-from hatchling.builders.utils import normalize_relative_path, get_reproducible_timestamp
+from hatchling.builders.utils import get_reproducible_timestamp
+from hatchling.builders.utils import normalize_relative_path
 from hatchling.metadata.spec import DEFAULT_METADATA_VERSION
 from hatchling.metadata.spec import get_core_metadata_constructors
 

--- a/hatch_zipped_directory/builder.py
+++ b/hatch_zipped_directory/builder.py
@@ -52,10 +52,12 @@ class ZipArchive:
             self.zipfd.writestr(info, f.read())
 
     def write_file(self, path: str, data: bytes | str) -> None:
-        info = ZipInfo(os.fspath(self.root_path / path))
-        if self.ziptime:
-            info.date_time = self.ziptime
-        self.zipfd.writestr(info, data)
+        arcname = self.root_path / path
+        if self.ziptime is not None:
+            date_time = self.ziptime
+        else:
+            date_time = time.localtime(time.time())[:6]
+        self.zipfd.writestr(ZipInfo(os.fspath(arcname), date_time=date_time), data)
 
     @classmethod
     @contextmanager

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,7 +1,7 @@
-import hashlib
 import json
 import os
 import re
+import time
 from pathlib import Path
 from zipfile import ZipFile
 
@@ -11,18 +11,6 @@ from hatchling.metadata.core import ProjectMetadata
 
 from hatch_zipped_directory.builder import ZipArchive
 from hatch_zipped_directory.builder import ZippedDirectoryBuilder
-
-READ_SIZE = 65536
-
-
-def getsha256(filename) -> str:
-    sha256 = hashlib.sha256()
-    with open(filename, "rb") as f:
-        data = f.read(READ_SIZE)
-        while data:
-            sha256.update(data)
-            data = f.read(READ_SIZE)
-    return sha256.hexdigest()
 
 
 def zip_contents(path):
@@ -34,95 +22,120 @@ def zip_contents(path):
     return files
 
 
-def zip_timestamps(path):
-    zf = ZipFile(path)
-    timestamps = []
-    for info in zf.infolist():
-        timestamps.append(info.date_time)
-    return timestamps
+@pytest.fixture(
+    params=[
+        pytest.param(True, id="[reproducible]"),
+        pytest.param(True, id="[non-reproducible]"),
+    ]
+)
+def reproducible(request: pytest.FixtureRequest) -> bool:
+    return request.param
 
 
-def assert_zip_timestamps(archive_path, reproducible: bool):
-    if reproducible:
-        condition = lambda t: t == (2020, 2, 2, 0, 0, 0)
-    else:
-        condition = lambda t: t != (2020, 2, 2, 0, 0, 0)
-    assert all(condition(t) for t in zip_timestamps(archive_path))
+def test_ZipArchive_cleanup_on_error_in_init(tmp_path, monkeypatch, reproducible):
+    monkeypatch.delattr("hatch_zipped_directory.builder.ZipFile")
+
+    with pytest.raises(NameError):
+        with ZipArchive.open(
+            tmp_path / "test.zip", "install_name", reproducible=reproducible
+        ):
+            pass  # no cov
+    assert len(list(tmp_path.iterdir())) == 0
+
+
+def test_ZipArchive_cleanup_on_error(tmp_path, reproducible):
+    archive_path = tmp_path / "test.zip"
+    with pytest.raises(RuntimeError):
+        with ZipArchive.open(archive_path, "install_name", reproducible=reproducible):
+            raise RuntimeError("test")
+    assert len(list(tmp_path.iterdir())) == 0
 
 
 @pytest.mark.parametrize(
-    "reproducible",
-    [True, False],
-    ids=lambda val: "[reproducible]" if val else "[non-reproducible]",
+    "install_name, arcname_prefix",
+    [
+        ("install_prefix", "install_prefix/"),
+        ("", ""),
+        (".", ""),
+    ],
 )
-class TestZipArchive:
-    def test_cleanup_on_error_in_init(self, tmp_path, monkeypatch, reproducible):
-        monkeypatch.delattr("hatch_zipped_directory.builder.ZipFile")
-
-        with pytest.raises(NameError):
-            with ZipArchive.open(
-                tmp_path / "test.zip", "install_name", reproducible=reproducible
-            ):
-                pass  # no cov
-        assert len(list(tmp_path.iterdir())) == 0
-
-    def test_cleanup_on_error(self, tmp_path, reproducible):
-        archive_path = tmp_path / "test.zip"
-        with pytest.raises(RuntimeError):
-            with ZipArchive.open(
-                archive_path, "install_name", reproducible=reproducible
-            ):
-                raise RuntimeError("test")
-        assert len(list(tmp_path.iterdir())) == 0
-
-    @pytest.mark.parametrize(
-        "install_name, arcname_prefix",
-        [
-            ("install_prefix", "install_prefix/"),
-            ("", ""),
-            (".", ""),
-        ],
+def test_ZipArchive_add_file(tmp_path, reproducible, install_name, arcname_prefix):
+    relative_path = "src/foo"
+    path = tmp_path / relative_path
+    path.parent.mkdir(parents=True)
+    path.write_text("content")
+    distribution_path = "bar"
+    included_file = IncludedFile(
+        os.fspath(tmp_path / relative_path), relative_path, distribution_path
     )
-    def test_add_file(self, tmp_path, reproducible, install_name, arcname_prefix):
-        relative_path = "src/foo"
-        path = tmp_path / relative_path
-        path.parent.mkdir(parents=True)
-        path.write_text("content")
-        distribution_path = "bar"
-        included_file = IncludedFile(
-            os.fspath(tmp_path / relative_path), relative_path, distribution_path
-        )
 
-        archive_path = tmp_path / "test.zip"
-        with ZipArchive.open(
-            archive_path, install_name, reproducible=reproducible
-        ) as archive:
-            archive.add_file(included_file)
+    archive_path = tmp_path / "test.zip"
+    with ZipArchive.open(
+        archive_path, install_name, reproducible=reproducible
+    ) as archive:
+        archive.add_file(included_file)
 
-        assert zip_contents(archive_path) == {
-            f"{arcname_prefix}bar": "content",
-        }
-        assert_zip_timestamps(archive_path, reproducible)
+    assert zip_contents(archive_path) == {
+        f"{arcname_prefix}bar": "content",
+    }
 
-    @pytest.mark.parametrize(
-        "install_name, arcname_prefix",
-        [
-            ("install_prefix", "install_prefix/"),
-            ("", ""),
-            (".", ""),
-        ],
-    )
-    def test_write_file(self, tmp_path, reproducible, install_name, arcname_prefix):
-        archive_path = tmp_path / "test.zip"
-        with ZipArchive.open(
-            archive_path, install_name, reproducible=reproducible
-        ) as archive:
-            archive.write_file("foo", "contents\n")
 
-        assert zip_contents(archive_path) == {
-            f"{arcname_prefix}foo": "contents\n",
-        }
-        assert_zip_timestamps(archive_path, reproducible)
+@pytest.mark.parametrize(
+    "install_name, arcname_prefix",
+    [
+        ("install_prefix", "install_prefix/"),
+        ("", ""),
+        (".", ""),
+    ],
+)
+def test_ZipArchive_write_file(tmp_path, reproducible, install_name, arcname_prefix):
+    archive_path = tmp_path / "test.zip"
+    with ZipArchive.open(
+        archive_path, install_name, reproducible=reproducible
+    ) as archive:
+        archive.write_file("foo", "contents\n")
+
+    assert zip_contents(archive_path) == {
+        f"{arcname_prefix}foo": "contents\n",
+    }
+
+
+def test_ZipArchive_reproducible_timestamps(tmp_path: Path) -> None:
+    archive_path = tmp_path / "test.zip"
+    src_path = tmp_path / "bar"
+    src_path.touch()
+
+    with ZipArchive.open(archive_path, root_path="", reproducible=True) as archive:
+        archive.write_file("foo", "contents\n")
+        archive.add_file(IncludedFile(os.fspath(src_path), "bar", "bar"))
+
+    with ZipFile(archive_path) as zf:
+        infolist = zf.infolist()
+    assert len(infolist) == 2
+    reproducible_ts = (2020, 2, 2, 0, 0, 0)
+    assert all(info.date_time == reproducible_ts for info in infolist)
+
+
+def test_ZipArchive_copies_timestamps_if_not_reproducible(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    now = int(time.time() // 2) * 2  # NB: Zip timestamps have 2-second resolution
+    now_date_tuple = time.localtime(now)[:6]
+    monkeypatch.setattr("time.time", lambda: float(now))
+
+    archive_path = tmp_path / "test.zip"
+    src_path = tmp_path / "bar"
+    src_path.touch()
+    os.utime(src_path, (now, now))
+
+    with ZipArchive.open(archive_path, root_path="", reproducible=False) as archive:
+        archive.write_file("foo", "contents\n")
+        archive.add_file(IncludedFile(os.fspath(src_path), "bar", "bar"))
+
+    with ZipFile(archive_path) as zf:
+        infolist = zf.infolist()
+    assert len(infolist) == 2
+    assert all(info.date_time == now_date_tuple for info in infolist)
 
 
 @pytest.fixture
@@ -221,39 +234,29 @@ def test_ZippedDirectoryBuilder_build(builder, project_root, tmp_path, arcname_p
         f"{arcname_prefix}test.txt",
         f"{arcname_prefix}METADATA.json",
     }
-    assert_zip_timestamps(artifact, reproducible=True)
     json_metadata = json.loads(contents[f"{arcname_prefix}METADATA.json"])
     assert json_metadata["version"] == "1.23"
 
 
-@pytest.mark.parametrize(
-    "target_config",
-    [
-        {"reproducible": True},
-        {"reproducible": False},
-    ],
-)
-def test_ZippedDirectoryBuilder_reproducible(
-    builder, project_root, tmp_path, target_config
-):
+@pytest.mark.parametrize("target_config", [{"reproducible": True}])
+def test_ZippedDirectoryBuilder_reproducible(builder, project_root, tmp_path):
     dist_path = tmp_path / "dist"
     test_file = project_root.joinpath("test.txt")
     test_file.write_text("content")
 
-    digests = []
-    for _ in range(0, 2):
+    def build() -> Path:
         artifacts = list(builder.build(os.fspath(dist_path)))
         assert len(artifacts) == 1
-        artifact = Path(artifacts[0])
-        digests.append(getsha256(artifact))
-        os.remove(artifact)
-        # use some random epoch from the past, when `reproducible` enabled
-        # then digest of archive should not change
-        os.utime(test_file, (968250745, 968250745))
-    if target_config["reproducible"]:
-        assert digests[0] == digests[1]
-    else:
-        assert digests[0] != digests[1]
+        return Path(artifacts[0])
+
+    zip1 = build()
+
+    # use some random epoch from the past, when `reproducible` enabled
+    # then digest of archive should not change
+    os.utime(test_file, (968250745, 968250745))
+    zip2 = build()
+
+    assert zip1.read_bytes() == zip2.read_bytes()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -18,8 +18,10 @@ READ_SIZE = 65536
 def getsha256(filename) -> str:
     sha256 = hashlib.sha256()
     with open(filename, "rb") as f:
-        while data := f.read(READ_SIZE):
+        data = f.read(READ_SIZE)
+        while data:
             sha256.update(data)
+            data = f.read(READ_SIZE)
     return sha256.hexdigest()
 
 


### PR DESCRIPTION
See [1] for more info about reproducible builds. In case of zip files we need to adjust timestamps. After this change, each built zip archive will have same hash (as long as packaged files do not change)

[1] https://hatch.pypa.io/latest/config/build/#reproducible-builds