### PR TITLE
Add the explicit writing of directory ZIP information to archive

### DIFF
--- a/hatch_zipped_directory/builder.py
+++ b/hatch_zipped_directory/builder.py
@@ -9,6 +9,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from functools import cached_property
 from pathlib import Path
+from pathlib import PurePosixPath
 from typing import Any
 from typing import Callable
 from zipfile import ZIP_DEFLATED
@@ -34,7 +35,7 @@ __all__ = ["ZippedDirectoryBuilder"]
 
 class ZipArchive:
     def __init__(self, zipfd: ZipFile, root_path: str, *, reproducible: bool = True):
-        self.root_path = Path(root_path)
+        self.root_path = PurePosixPath(root_path)
         self.zipfd = zipfd
         self.reproducible = reproducible
 

--- a/hatch_zipped_directory/builder.py
+++ b/hatch_zipped_directory/builder.py
@@ -9,7 +9,6 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from functools import cached_property
 from pathlib import Path
-from pathlib import PurePosixPath
 from typing import Any
 from typing import Callable
 from zipfile import ZIP_DEFLATED
@@ -35,7 +34,7 @@ __all__ = ["ZippedDirectoryBuilder"]
 
 class ZipArchive:
     def __init__(self, zipfd: ZipFile, root_path: str, *, reproducible: bool = True):
-        self.root_path = PurePosixPath(root_path)
+        self.root_path = Path(root_path)
         self.zipfd = zipfd
         self.reproducible = reproducible
 

--- a/hatch_zipped_directory/builder.py
+++ b/hatch_zipped_directory/builder.py
@@ -9,7 +9,6 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from functools import cached_property
 from pathlib import Path
-from pathlib import PurePath
 from typing import Any
 from typing import Callable
 from zipfile import ZIP_DEFLATED
@@ -35,7 +34,7 @@ __all__ = ["ZippedDirectoryBuilder"]
 
 class ZipArchive:
     def __init__(self, zipfd: ZipFile, root_path: str, *, reproducible: bool = True):
-        self.root_path = PurePath(root_path)
+        self.root_path = Path(root_path)
         self.zipfd = zipfd
         self.reproducible = reproducible
 

--- a/hatch_zipped_directory/builder.py
+++ b/hatch_zipped_directory/builder.py
@@ -9,7 +9,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from functools import cached_property
 from pathlib import Path
-from pathlib import PurePosixPath
+from pathlib import PurePath
 from typing import Any
 from typing import Callable
 from zipfile import ZIP_DEFLATED
@@ -35,7 +35,7 @@ __all__ = ["ZippedDirectoryBuilder"]
 
 class ZipArchive:
     def __init__(self, zipfd: ZipFile, root_path: str, *, reproducible: bool = True):
-        self.root_path = PurePosixPath(root_path)
+        self.root_path = PurePath(root_path)
         self.zipfd = zipfd
         self.reproducible = reproducible
 
@@ -48,6 +48,10 @@ class ZipArchive:
             raise ValueError(  # no cov
                 "ZipArchive.add_file does not support adding directories"
             )
+
+        for parent_dir in reversed(arcname.parents[:-1]):
+            if (parent_dir.as_posix() + "/") not in self.zipfd.namelist():
+                self.zipfd.mkdir(parent_dir.as_posix())
 
         if self.reproducible:
             zinfo.date_time = self._reproducible_date_time

--- a/hatch_zipped_directory/builder.py
+++ b/hatch_zipped_directory/builder.py
@@ -49,9 +49,9 @@ class ZipArchive:
                 "ZipArchive.add_file does not support adding directories"
             )
 
-        for parent_dir in reversed(arcname.parents[:-1]):
+        for parent_dir in reversed(list(arcname.parents)[:-1]):
             if (parent_dir.as_posix() + "/") not in self.zipfd.namelist():
-                self.zipfd.mkdir(parent_dir.as_posix())
+                self.zipfd.writestr(parent_dir.as_posix() + "/", "")
 
         if self.reproducible:
             zinfo.date_time = self._reproducible_date_time

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -3,7 +3,8 @@ import os
 import re
 import stat
 import time
-from pathlib import Path, PurePath
+from pathlib import Path
+from pathlib import PurePath
 from zipfile import ZipFile
 
 import pytest
@@ -69,9 +70,11 @@ def test_ZipArchive_add_file(tmp_path, reproducible, install_name, arcname_prefi
         if not path.parent.exists():
             path.parent.mkdir(parents=True)
         path.write_text("content")
-        included_files.append(IncludedFile(
-            os.fspath(tmp_path / relative_path), relative_path, distribution_path
-        ))
+        included_files.append(
+            IncludedFile(
+                os.fspath(tmp_path / relative_path), relative_path, distribution_path
+            )
+        )
 
     archive_path = tmp_path / "test.zip"
     with ZipArchive.open(

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -65,16 +65,17 @@ def test_ZipArchive_add_file(tmp_path, reproducible, install_name, arcname_prefi
     relative_paths = ["src/foo", "src/goo"]
     distribution_paths = ["bar", "ber"]
     included_files = []
+    expected_contents = {}
     for relative_path, distribution_path in zip(relative_paths, distribution_paths):
         path = tmp_path / relative_path
-        if not path.parent.exists():
-            path.parent.mkdir(parents=True)
+        path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("content")
         included_files.append(
             IncludedFile(
                 os.fspath(tmp_path / relative_path), relative_path, distribution_path
             )
         )
+        expected_contents[f"{arcname_prefix}{distribution_path}"] = "content"
 
     archive_path = tmp_path / "test.zip"
     with ZipArchive.open(
@@ -82,11 +83,6 @@ def test_ZipArchive_add_file(tmp_path, reproducible, install_name, arcname_prefi
     ) as archive:
         for included_file in included_files:
             archive.add_file(included_file)
-
-    expected_contents = {
-        f"{arcname_prefix}bar": "content",
-        f"{arcname_prefix}ber": "content",
-    }
 
     directory_names = set()
     for k in expected_contents.keys():

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -61,23 +61,28 @@ def test_ZipArchive_cleanup_on_error(tmp_path, reproducible):
     ],
 )
 def test_ZipArchive_add_file(tmp_path, reproducible, install_name, arcname_prefix):
-    relative_path = "src/foo"
-    path = tmp_path / relative_path
-    path.parent.mkdir(parents=True)
-    path.write_text("content")
-    distribution_path = "bar"
-    included_file = IncludedFile(
-        os.fspath(tmp_path / relative_path), relative_path, distribution_path
-    )
+    relative_paths = ["src/foo", "src/goo"]
+    distribution_paths = ["bar", "ber"]
+    included_files = []
+    for relative_path, distribution_path in zip(relative_paths, distribution_paths):
+        path = tmp_path / relative_path
+        if not path.parent.exists():
+            path.parent.mkdir(parents=True)
+        path.write_text("content")
+        included_files.append(IncludedFile(
+            os.fspath(tmp_path / relative_path), relative_path, distribution_path
+        ))
 
     archive_path = tmp_path / "test.zip"
     with ZipArchive.open(
         archive_path, install_name, reproducible=reproducible
     ) as archive:
-        archive.add_file(included_file)
+        for included_file in included_files:
+            archive.add_file(included_file)
 
     expected_contents = {
         f"{arcname_prefix}bar": "content",
+        f"{arcname_prefix}ber": "content",
     }
 
     directory_names = set()

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -4,6 +4,7 @@ import re
 import stat
 import time
 from pathlib import Path
+from pathlib import PurePosixPath
 from zipfile import ZipFile
 
 import pytest
@@ -89,8 +90,8 @@ def test_ZipArchive_add_file(tmp_path, reproducible, install_name, arcname_prefi
 
     directory_names = set()
     for k in expected_contents.keys():
-        for parent in Path(k).parents:
-            if parent != Path("."):
+        for parent in PurePosixPath(k).parents:
+            if parent != PurePosixPath("."):
                 directory_names.add(parent.as_posix() + "/")
 
     for d in directory_names:
@@ -289,8 +290,8 @@ def test_ZippedDirectoryBuilder_build(builder, project_root, tmp_path, arcname_p
 
     directory_names = set()
     for k in expected_contents:
-        for parent in Path(k).parents:
-            if parent != Path("."):
+        for parent in PurePosixPath(k).parents:
+            if parent != PurePosixPath("."):
                 directory_names.add(parent.as_posix() + "/")
 
     for d in directory_names:

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -4,7 +4,6 @@ import re
 import stat
 import time
 from pathlib import Path
-from pathlib import PurePath
 from zipfile import ZipFile
 
 import pytest
@@ -90,8 +89,8 @@ def test_ZipArchive_add_file(tmp_path, reproducible, install_name, arcname_prefi
 
     directory_names = set()
     for k in expected_contents.keys():
-        for parent in PurePath(k).parents:
-            if parent != PurePath("."):
+        for parent in Path(k).parents:
+            if parent != Path("."):
                 directory_names.add(parent.as_posix() + "/")
 
     for d in directory_names:
@@ -290,8 +289,8 @@ def test_ZippedDirectoryBuilder_build(builder, project_root, tmp_path, arcname_p
 
     directory_names = set()
     for k in expected_contents:
-        for parent in PurePath(k).parents:
-            if parent != PurePath("."):
+        for parent in Path(k).parents:
+            if parent != Path("."):
                 directory_names.add(parent.as_posix() + "/")
 
     for d in directory_names:

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -5,7 +5,6 @@ import stat
 import time
 from collections.abc import Iterable
 from pathlib import Path
-from pathlib import PurePosixPath
 from zipfile import ZipFile
 
 import pytest
@@ -33,7 +32,7 @@ def _parent_paths(paths: Iterable[str]) -> set[str]:
     return {
         f"{parent}/"
         for path in paths
-        for parent in PurePosixPath(path).parents
+        for parent in Path(path).parents
         if parent.name != ""
     }
 


### PR DESCRIPTION
Python cannot import packages and modules from ZIP files that do not have ZIP information about the archived directories. These changes ensure that information about the directories within the archive are explicitly included in the archive before writing the file data.