### PR TITLE
Fix for bitwise-identical output under Windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,12 +4,20 @@
 
 Drop support for python 3.9, test under python 3.15.
 
+#### Bugs Fixed
+
+- When running in reproducible mode (the default), force the "create system"
+  flag to "unix" in the zip archive file headers, in order to create bit-wise
+  identical results regardless of OS. Fixes [#7].
+
 #### Tests Fixed
 
 - Fix the functional test for `hatchling` == 1.32 which changes to
   emitting core metadata version 2.5.  This results in a change to the
   generated `METADATA.json`, and so a change to the SHA of the
   generated zip archive.
+
+[#7]: https://github.com/dairiki/hatch-zipped-directory/issues/7
 
 ### 0.2.1 (2025-06-06)
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ By default, this plugin attempts to build [reproducible][reproducible
 builds] archives by setting the timestamps of the zip entries to a
 fixed value. When building in reproducible mode, the UNIX file modes
 of the archive entries is also normalized (to either 0644 or 0755
-depending on whether the file is executable.)
+depending on whether the file is executable).  As well, in
+reproducible mode, the _"create system"_ flag in the zip file headers
+are forced to _Unix_, even when running under Windows.
 
 The timestamp used for reproducible builds may be configured by
 setting the `SOURCE_DATE_EPOCH` environment variable.

--- a/hatch_zipped_directory/builder.py
+++ b/hatch_zipped_directory/builder.py
@@ -33,6 +33,8 @@ from .utils import atomic_write
 
 __all__ = ["ZippedDirectoryBuilder"]
 
+_CREATE_SYSTEM_UNIX = 3
+
 
 class ZipArchive:
     def __init__(self, zipfd: ZipFile, root_path: str, *, reproducible: bool = True):
@@ -59,6 +61,7 @@ class ZipArchive:
             # normalize mode (https://github.com/takluyver/flit/pull/66)
             st_mode = (zinfo.external_attr >> 16) & 0xFFFF
             set_zip_info_mode(zinfo, normalize_file_permissions(st_mode) & 0xFFFF)
+            zinfo.create_system = _CREATE_SYSTEM_UNIX  # force on Windows
 
         with open(included_file.path, "rb") as src, self.zipfd.open(zinfo, "w") as dest:
             shutil.copyfileobj(src, dest, 8 * 1024)  # type: ignore[misc] # mypy #14975
@@ -66,10 +69,13 @@ class ZipArchive:
     def write_file(self, path: str, data: bytes | str) -> None:
         arcname = self.root_path / path
         if self.reproducible:
-            date_time = self._reproducible_date_time
+            zinfo = ZipInfo(os.fspath(arcname), date_time=self._reproducible_date_time)
+            zinfo.create_system = _CREATE_SYSTEM_UNIX  # force on Windows
         else:
-            date_time = time.localtime(time.time())[:6]
-        self.zipfd.writestr(ZipInfo(os.fspath(arcname), date_time=date_time), data)
+            zinfo = ZipInfo(
+                os.fspath(arcname), date_time=time.localtime(time.time())[:6]
+            )
+        self.zipfd.writestr(zinfo, data)
 
     @classmethod
     @contextmanager
@@ -103,6 +109,7 @@ class ZipArchive:
 
         if self.reproducible:
             zinfo.date_time = self._reproducible_date_time
+            zinfo.create_system = _CREATE_SYSTEM_UNIX  # force on Windows
 
         if sys.version_info < (3, 11):
             self.zipfd.writestr(zinfo, "")

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -109,13 +109,4 @@ def test_build_demo(demo_zipfile_path):
 def test_demo_zipfile_hash(demo_zipfile_path):
     with open(demo_zipfile_path, "rb") as fp:
         zip_sha1 = hashlib.sha1(fp.read()).hexdigest()
-
-    # FIXME: On windows hash appears to come out different.
-    # I haven't yet determined why.
-    if (  # pragma: no cover
-        sys.platform == "win32"
-        and zip_sha1 == "4070682225beb56de446ea785e748df07917998f"
-    ):
-        pytest.xfail("hash differs on windows for undetermined reason")
-
     assert zip_sha1 == "8a54ccba3119e8700a121a872c40e934e883783f"


### PR DESCRIPTION
When running in reproducible mode (the default), force the "create system" flag to "unix" in the zip archive file headers.
This results in bit-wise identical results regardless of OS.

Fixes #7.